### PR TITLE
Apply the screen resoultion policy of the iOS version.

### DIFF
--- a/Android/app/src/main/java/io/realm/draw/MainActivity.java
+++ b/Android/app/src/main/java/io/realm/draw/MainActivity.java
@@ -47,10 +47,9 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
     private static final String AUTH_URL = "http://" + BuildConfig.OBJECT_SERVER_IP + ":9080/auth";
     private static final String ID = "demo@realm.io";
     private static final String PASSWORD = "password";
-    private static final int EDGE_WIDTH = 683;
+    private static final double RATIO = 0.5;
     private volatile Realm realm;
     private SurfaceView surfaceView;
-    private double ratio = -1;
     private double marginLeft;
     private double marginTop;
     private DrawThread drawThread;
@@ -155,8 +154,8 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
                 || action == MotionEvent.ACTION_CANCEL) {
             float x = event.getRawX();
             float y = event.getRawY();
-            double pointX = (x - marginLeft - viewLocation[0]) * ratio;
-            double pointY = (y - marginTop - viewLocation[1]) * ratio;
+            double pointX = (x - marginLeft - viewLocation[0]) * RATIO;
+            double pointY = (y - marginTop - viewLocation[1]) * RATIO;
 
             if (action == MotionEvent.ACTION_DOWN) {
                 realm.beginTransaction();
@@ -207,16 +206,8 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
     public void surfaceChanged(SurfaceHolder surfaceHolder, int format, int width, int height) {
         boolean isPortrait = width < height;
         if (isPortrait) {
-            ratio = (double) EDGE_WIDTH / height;
-        } else {
-            ratio = (double) EDGE_WIDTH / width;
-        }
-        if (isPortrait) {
             marginLeft = (width - height) / 2.0;
             marginTop = 0;
-        } else {
-            marginLeft = 0;
-            marginTop = (height - width) / 2.0;
         }
     }
 
@@ -226,7 +217,6 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
             drawThread.shutdown();
             drawThread = null;
         }
-        ratio = -1;
     }
 
     @Override
@@ -260,9 +250,6 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
 
         @Override
         public void run() {
-            while (ratio < 0 && !isInterrupted()) {
-            }
-
             if (isInterrupted()) {
                 return;
             }
@@ -306,17 +293,17 @@ public class MainActivity extends AppCompatActivity implements SurfaceHolder.Cal
                                 paint.setColor(nameToColorMap.get(currentColor));
                             }
                             paint.setStyle(Paint.Style.STROKE);
-                            paint.setStrokeWidth((float) (4 / ratio));
+                            paint.setStrokeWidth((float) (4 / RATIO));
                             final Iterator<DrawPoint> iterator = points.iterator();
                             final DrawPoint firstPoint = iterator.next();
                             final Path path = new Path();
-                            final float firstX = (float) ((firstPoint.getX() / ratio) + marginLeft);
-                            final float firstY = (float) ((firstPoint.getY() / ratio) + marginTop);
+                            final float firstX = (float) ((firstPoint.getX() / RATIO) + marginLeft);
+                            final float firstY = (float) ((firstPoint.getY() / RATIO) + marginTop);
                             path.moveTo(firstX, firstY);
                             while(iterator.hasNext()) {
                                 DrawPoint point = iterator.next();
-                                final float x = (float) ((point.getX() / ratio) + marginLeft);
-                                final float y = (float) ((point.getY() / ratio) + marginTop);
+                                final float x = (float) ((point.getX() / RATIO) + marginLeft);
+                                final float y = (float) ((point.getY() / RATIO) + marginTop);
                                 path.lineTo(x, y);
                             }
                             canvas.drawPath(path, paint);

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -23,8 +23,7 @@
     <SurfaceView
         android:id="@+id/surface_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="60dp"/>
+        android:layout_height="match_parent"/>
 
     <RelativeLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
<img width="1414" alt="screen shot 2016-12-16 at 3 59 33 pm" src="https://cloud.githubusercontent.com/assets/145585/21255128/3fa4013a-c3ad-11e6-9713-4a74b9d34c80.png">

The mobile device uses 667 x 667 or 736 x 736 (Plus version) and tablet device version 1024 x 1024 or 1366 x 1366 (Pro version). It always uses a canvas depends on the device’s logical resolution. (logical height x logical height) 
I checked the logical resolution is same with the following link: http://iosres.com/

The logical resolution is half scale of the resolution, so I just use half scale for all devices.