### PR TITLE
Ad/xamarin/draw minor fixes updates for launch

### DIFF
--- a/Xamarin/DrawXShared/DrawXSettingsManager.cs
+++ b/Xamarin/DrawXShared/DrawXSettingsManager.cs
@@ -20,6 +20,8 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Realms;
+using Realms.Exceptions;
+using Realms.Sync;
 
 namespace DrawXShared
 {
@@ -27,6 +29,7 @@ namespace DrawXShared
     {
         private static Realm _localSettingsRealm;
         private static DrawXSettings _savedSettings;
+        internal static User LoggedInUser {get; private set; }  // hides the exception handling of User.Current
 
         public static DrawXSettings Settings
         {
@@ -56,6 +59,15 @@ namespace DrawXShared
             settingsConf.ObjectClasses = new[] { typeof(DrawXSettings) };
             settingsConf.SchemaVersion = 2;  // set explicitly and bump as we add setting properties
             _localSettingsRealm = Realm.GetInstance(settingsConf);
+            try
+            {
+                LoggedInUser = User.Current;
+            }
+            catch (RealmException re)
+            {
+                // do nothing - assume multiple users logged in so will have to use login dialog to choose
+                // TODO - present a Currently Logged in picker in this case?
+            }
         }
 
         // bit of a hack which only works when the caller has objects already on the _realmLocalSettings Realm
@@ -72,9 +84,10 @@ namespace DrawXShared
                 serverIP += ":9080";
             }
 
-            // crashes if ServerIP is null            bool changedServer = string.IsNullOrEmpty(_savedSettings.ServerIP) || !_savedSettings.ServerIP.Equals(serverIP);
             var changedServer = _savedSettings.ServerIP == null ||
-                                 !_savedSettings.ServerIP.Equals(serverIP);
+              !_savedSettings.ServerIP.Equals(serverIP) ||
+              !_savedSettings.Username.Equals(username) ||
+              !_savedSettings.Password.Equals(password);
             _localSettingsRealm.Write(() =>
             {
                 _savedSettings.ServerIP = serverIP;

--- a/Xamarin/DrawXShared/DrawXSettingsManager.cs
+++ b/Xamarin/DrawXShared/DrawXSettingsManager.cs
@@ -29,7 +29,23 @@ namespace DrawXShared
     {
         private static Realm _localSettingsRealm;
         private static DrawXSettings _savedSettings;
-        internal static User LoggedInUser {get; private set; }  // hides the exception handling of User.Current
+        internal static User LoggedInUser
+        {
+            get
+            {
+                // hides the exception handling of User.Current
+                try
+                {
+                    return User.Current;
+                }
+                catch (RealmException re)
+                {
+                    // do nothing - assume multiple users logged in so will have to use login dialog to choose
+                    // TODO - present a Currently Logged in picker in this case?
+                    return null;
+                }
+            }
+        }
 
         public static DrawXSettings Settings
         {
@@ -59,15 +75,6 @@ namespace DrawXShared
             settingsConf.ObjectClasses = new[] { typeof(DrawXSettings) };
             settingsConf.SchemaVersion = 2;  // set explicitly and bump as we add setting properties
             _localSettingsRealm = Realm.GetInstance(settingsConf);
-            try
-            {
-                LoggedInUser = User.Current;
-            }
-            catch (RealmException re)
-            {
-                // do nothing - assume multiple users logged in so will have to use login dialog to choose
-                // TODO - present a Currently Logged in picker in this case?
-            }
         }
 
         // bit of a hack which only works when the caller has objects already on the _realmLocalSettings Realm

--- a/Xamarin/DrawXShared/RealmDraw.cs
+++ b/Xamarin/DrawXShared/RealmDraw.cs
@@ -159,7 +159,6 @@ namespace DrawXShared
 
         public RealmDraw(float inWidth, float inHeight)
         {
-            // TODO close the Realm
             _canvasWidth = inWidth;
             _canvasHeight = inHeight;
 
@@ -247,6 +246,13 @@ namespace DrawXShared
                 {
                     ReportError(true, $"Credentials accepted at {s.ServerIP} but then failed to open Realm: {e.GetType().FullName} {e.Message}");
                 }
+            }
+
+            if (user != null)
+            {
+                // cleanup the graphics
+                InvalidateCachedPaths();
+                RefreshOnRealmUpdate();
             }
 
             _waitingForLogin = false;

--- a/Xamarin/DrawXShared/ViewControllerShared.cs
+++ b/Xamarin/DrawXShared/ViewControllerShared.cs
@@ -92,9 +92,10 @@ namespace DrawX.IOS
                 if (View.Bounds != _prevBounds)
                 {
                     SetupDrawer();
-                    if (DrawXSettingsManager.LoggedInUser != null)
+                    var user = DrawXSettingsManager.LoggedInUser;
+                    if (user != null)
                     {
-                        _drawer.LoginToServerAsync(DrawXSettingsManager.LoggedInUser);
+                        _drawer.LoginToServerAsync(user);
                         _hasShownCredentials = true;  // skip credentials if saved user in store
                     }
                     View?.SetNeedsDisplay();

--- a/Xamarin/DrawXShared/ViewControllerShared.cs
+++ b/Xamarin/DrawXShared/ViewControllerShared.cs
@@ -180,7 +180,6 @@ namespace DrawX.IOS
 
         private void EditCredentials()
         {
-            // TODO generalise this to work in either this or DrawX.iOS project
             var sb = UIStoryboard.FromName("LoginScreen", null);
             var loginVC = sb.InstantiateViewController("Login") as LoginViewController;
             loginVC.OnCloseLogin = (bool changedServer) =>

--- a/Xamarin/DrawXShared/ViewControllerShared.cs
+++ b/Xamarin/DrawXShared/ViewControllerShared.cs
@@ -67,10 +67,18 @@ namespace DrawX.IOS
             {
                 InvokeOnMainThread(EditCredentials);
             };
+
             _drawer.RefreshOnRealmUpdate = () =>
             {
                 Debug.WriteLine("Refresh callback triggered by Realm");
                 View?.SetNeedsDisplay();  // just refresh on notification, OnPaintSample below triggers DrawTouches
+            };
+
+            _drawer.ReportError = (bool isError, string msg) =>
+            {
+                var alertController = UIAlertController.Create(isError?"Realm Error":"Warning", msg, UIAlertControllerStyle.Alert);
+                alertController.AddAction(UIAlertAction.Create("Ok", UIAlertActionStyle.Default, null));
+                PresentViewController(alertController, true, null);
             };
         }
 
@@ -165,7 +173,7 @@ namespace DrawX.IOS
                 {
                     alert.PopoverPresentationController.SourceView = View;
                 }
-                PresentViewController(alert, animated:true, completionHandler:null);
+                PresentViewController(alert, animated: true, completionHandler: null);
                 //// unlike other gesture actions, don't call View.SetNeedsDisplay but let major Realm change prompt redisplay
             }
         }

--- a/Xamarin/Droid/DrawX.Droid.csproj
+++ b/Xamarin/Droid/DrawX.Droid.csproj
@@ -51,16 +51,16 @@
       <HintPath>..\packages\Remotion.Linq.2.1.1\lib\portable-net45+win+wpa81+wp80\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp">
-      <HintPath>..\packages\SkiaSharp.1.55.1\lib\MonoAndroid\SkiaSharp.dll</HintPath>
+      <HintPath>..\packages\SkiaSharp.1.56.0\lib\MonoAndroid\SkiaSharp.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp.Views.Android">
-      <HintPath>..\packages\SkiaSharp.Views.1.55.1\lib\MonoAndroid\SkiaSharp.Views.Android.dll</HintPath>
+      <HintPath>..\packages\SkiaSharp.Views.1.56.0\lib\MonoAndroid\SkiaSharp.Views.Android.dll</HintPath>
     </Reference>
     <Reference Include="Realm">
-      <HintPath>..\packages\Realm.Database.0.81.0\lib\MonoAndroid44\Realm.dll</HintPath>
+      <HintPath>..\packages\Realm.Database.0.83.0\lib\MonoAndroid44\Realm.dll</HintPath>
     </Reference>
     <Reference Include="Realm.Sync">
-      <HintPath>..\packages\Realm.0.81.0\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
+      <HintPath>..\packages\Realm.0.83.0\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -93,5 +93,6 @@
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\Realm.0.80.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.80.0\build\Realm.targets')" />
   <Import Project="..\packages\Realm.Database.0.81.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.81.0\build\Realm.Database.targets')" />
-  <Import Project="..\packages\Realm.0.81.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.81.0\build\Realm.targets')" />
+  <Import Project="..\packages\Realm.Database.0.83.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.83.0\build\Realm.Database.targets')" />
+  <Import Project="..\packages\Realm.0.83.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.83.0\build\Realm.targets')" />
 </Project>

--- a/Xamarin/Droid/DrawX.Droid.csproj
+++ b/Xamarin/Droid/DrawX.Droid.csproj
@@ -57,10 +57,10 @@
       <HintPath>..\packages\SkiaSharp.Views.1.56.0\lib\MonoAndroid\SkiaSharp.Views.Android.dll</HintPath>
     </Reference>
     <Reference Include="Realm">
-      <HintPath>..\packages\Realm.Database.0.83.0\lib\MonoAndroid44\Realm.dll</HintPath>
+      <HintPath>..\packages\Realm.Database.1.0.3\lib\MonoAndroid44\Realm.dll</HintPath>
     </Reference>
     <Reference Include="Realm.Sync">
-      <HintPath>..\packages\Realm.0.83.0\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
+      <HintPath>..\packages\Realm.1.0.3\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -93,6 +93,6 @@
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\Realm.0.80.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.80.0\build\Realm.targets')" />
   <Import Project="..\packages\Realm.Database.0.81.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.81.0\build\Realm.Database.targets')" />
-  <Import Project="..\packages\Realm.Database.0.83.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.83.0\build\Realm.Database.targets')" />
-  <Import Project="..\packages\Realm.0.83.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.83.0\build\Realm.targets')" />
+  <Import Project="..\packages\Realm.Database.1.0.3\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.1.0.3\build\Realm.Database.targets')" />
+  <Import Project="..\packages\Realm.1.0.3\build\Realm.targets" Condition="Exists('..\packages\Realm.1.0.3\build\Realm.targets')" />
 </Project>

--- a/Xamarin/Droid/MainActivity.cs
+++ b/Xamarin/Droid/MainActivity.cs
@@ -53,11 +53,25 @@ namespace DrawX.Droid
             {
                 EditCredentials();
             };
+
             _drawer.RefreshOnRealmUpdate = () =>
             {
                 System.Diagnostics.Debug.WriteLine("Refresh callback triggered by Realm");
                 _canvas.Invalidate();
             };
+
+            _drawer.ReportError = (bool isError, string msg) =>
+            {
+                AlertDialog.Builder alert = new AlertDialog.Builder (this);
+                alert.SetTitle (isError?"Realm Error":"Warning");
+                alert.SetMessage(msg);
+                alert.SetPositiveButton ("OK", (senderAlert, args) => {
+                } );
+
+                RunOnUiThread (() => {
+                    alert.Show();
+                } );}
+            ;
         }
 
         protected override void OnStart()

--- a/Xamarin/Droid/MainActivity.cs
+++ b/Xamarin/Droid/MainActivity.cs
@@ -89,6 +89,11 @@ namespace DrawX.Droid
                 }
             }
 
+            if (DrawXSettingsManager.LoggedInUser != null)
+            {
+                _drawer.LoginToServerAsync(DrawXSettingsManager.LoggedInUser);
+                _hasShownCredentials = true;  // skip credentials if saved user in store
+            }
             if (!_hasShownCredentials)
             {
                 EditCredentials();

--- a/Xamarin/Droid/MainActivity.cs
+++ b/Xamarin/Droid/MainActivity.cs
@@ -62,16 +62,18 @@ namespace DrawX.Droid
 
             _drawer.ReportError = (bool isError, string msg) =>
             {
-                AlertDialog.Builder alert = new AlertDialog.Builder (this);
-                alert.SetTitle (isError?"Realm Error":"Warning");
+                AlertDialog.Builder alert = new AlertDialog.Builder(this);
+                alert.SetTitle(isError ? "Realm Error" : "Warning");
                 alert.SetMessage(msg);
-                alert.SetPositiveButton ("OK", (senderAlert, args) => {
-                } );
+                alert.SetPositiveButton("OK", (senderAlert, args) =>
+                {
+                });
 
-                RunOnUiThread (() => {
+                RunOnUiThread(() =>
+                {
                     alert.Show();
-                } );}
-            ;
+                });
+            };
         }
 
         protected override void OnStart()
@@ -105,7 +107,7 @@ namespace DrawX.Droid
             {
                 return;  // in case managed to trigger before focus event finished setup
             }
-            
+
             float fx = touchEventArgs.Event.GetX();
             float fy = touchEventArgs.Event.GetY();
             var needsRefresh = false;

--- a/Xamarin/Droid/Screens/LoginDialog.cs
+++ b/Xamarin/Droid/Screens/LoginDialog.cs
@@ -68,7 +68,16 @@ namespace DrawX.Droid
             {
                 ((AlertDialog)sender).Dismiss();
             });
-            return builder.Create();
+            var dialog = builder.Create();
+
+            // you can only cancel logging in if already logged in, otherwise it is meaningless
+            if (DrawXSettingsManager.LoggedInUser == null)
+            {
+                dialog.Show();  // instantiates so buttons can be accessed
+                var negativeButton = dialog.GetButton((int)DialogButtonType.Negative);
+                negativeButton.Enabled = false;
+            }
+            return dialog;
         }
     }
 }

--- a/Xamarin/Droid/packages.config
+++ b/Xamarin/Droid/packages.config
@@ -2,20 +2,20 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="monoandroid70" />
   <package id="Fody" version="1.29.4" targetFramework="monoandroid70" developmentDependency="true" />
-  <package id="Realm" version="0.81.0" targetFramework="monoandroid70" developmentDependency="true" />
-  <package id="Realm.Database" version="0.81.0" targetFramework="monoandroid70" developmentDependency="true" />
+  <package id="Realm" version="0.83.0" targetFramework="monoandroid70" developmentDependency="true" />
+  <package id="Realm.Database" version="0.83.0" targetFramework="monoandroid70" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="monoandroid70" />
-  <package id="SkiaSharp" version="1.55.1" targetFramework="monoandroid70" />
-  <package id="SkiaSharp.Views" version="1.55.1" targetFramework="monoandroid70" />
-  <package id="System.Collections" version="4.0.11" targetFramework="monoandroid70" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="monoandroid70" />
-  <package id="System.Linq" version="4.1.0" targetFramework="monoandroid70" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="monoandroid70" />
-  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="monoandroid70" />
-  <package id="System.ObjectModel" version="4.0.12" targetFramework="monoandroid70" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="monoandroid70" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="monoandroid70" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="monoandroid70" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="monoandroid70" />
-  <package id="System.Threading" version="4.0.11" targetFramework="monoandroid70" />
+  <package id="SkiaSharp" version="1.56.0" targetFramework="monoandroid70" />
+  <package id="SkiaSharp.Views" version="1.56.0" targetFramework="monoandroid70" />
+  <package id="System.Collections" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Linq" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Linq.Queryable" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Threading" version="4.3.0" targetFramework="monoandroid70" />
 </packages>

--- a/Xamarin/Droid/packages.config
+++ b/Xamarin/Droid/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="monoandroid70" />
   <package id="Fody" version="1.29.4" targetFramework="monoandroid70" developmentDependency="true" />
-  <package id="Realm" version="0.83.0" targetFramework="monoandroid70" developmentDependency="true" />
-  <package id="Realm.Database" version="0.83.0" targetFramework="monoandroid70" developmentDependency="true" />
+  <package id="Realm" version="1.0.3" targetFramework="monoandroid70" developmentDependency="true" />
+  <package id="Realm.Database" version="1.0.3" targetFramework="monoandroid70" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="monoandroid70" />
   <package id="SkiaSharp" version="1.56.0" targetFramework="monoandroid70" />
   <package id="SkiaSharp.Views" version="1.56.0" targetFramework="monoandroid70" />

--- a/Xamarin/iOS/DrawX.iOS.csproj
+++ b/Xamarin/iOS/DrawX.iOS.csproj
@@ -118,17 +118,19 @@
     <Reference Include="Remotion.Linq">
       <HintPath>..\packages\Remotion.Linq.2.1.1\lib\portable-net45+win+wpa81+wp80\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="SkiaSharp">
-      <HintPath>..\packages\SkiaSharp.1.55.1\lib\XamariniOS\SkiaSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="SkiaSharp.Views.iOS">
-      <HintPath>..\packages\SkiaSharp.Views.1.55.1\lib\XamariniOS\SkiaSharp.Views.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="Realm">
-      <HintPath>..\packages\Realm.Database.0.81.0\lib\Xamarin.iOS10\Realm.dll</HintPath>
+      <HintPath>..\packages\Realm.Database.0.83.0\lib\Xamarin.iOS10\Realm.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Realm.Sync">
-      <HintPath>..\packages\Realm.0.81.0\lib\Xamarin.iOS10\Realm.Sync.dll</HintPath>
+      <HintPath>..\packages\Realm.0.83.0\lib\Xamarin.iOS10\Realm.Sync.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="SkiaSharp">
+      <HintPath>..\packages\SkiaSharp.1.56.0\lib\XamariniOS\SkiaSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SkiaSharp.Views.iOS">
+      <HintPath>..\packages\SkiaSharp.Views.1.56.0\lib\XamariniOS\SkiaSharp.Views.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -175,4 +177,6 @@
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\Realm.Database.0.81.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.81.0\build\Realm.Database.targets')" />
   <Import Project="..\packages\Realm.0.81.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.81.0\build\Realm.targets')" />
+  <Import Project="..\packages\Realm.Database.0.83.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.83.0\build\Realm.Database.targets')" />
+  <Import Project="..\packages\Realm.0.83.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.83.0\build\Realm.targets')" />
 </Project>

--- a/Xamarin/iOS/DrawX.iOS.csproj
+++ b/Xamarin/iOS/DrawX.iOS.csproj
@@ -118,19 +118,19 @@
     <Reference Include="Remotion.Linq">
       <HintPath>..\packages\Remotion.Linq.2.1.1\lib\portable-net45+win+wpa81+wp80\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Realm">
-      <HintPath>..\packages\Realm.Database.0.83.0\lib\Xamarin.iOS10\Realm.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Realm.Sync">
-      <HintPath>..\packages\Realm.0.83.0\lib\Xamarin.iOS10\Realm.Sync.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="SkiaSharp">
       <HintPath>..\packages\SkiaSharp.1.56.0\lib\XamariniOS\SkiaSharp.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp.Views.iOS">
       <HintPath>..\packages\SkiaSharp.Views.1.56.0\lib\XamariniOS\SkiaSharp.Views.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Realm">
+      <HintPath>..\packages\Realm.Database.1.0.3\lib\Xamarin.iOS10\Realm.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Realm.Sync">
+      <HintPath>..\packages\Realm.1.0.3\lib\Xamarin.iOS10\Realm.Sync.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -177,6 +177,6 @@
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\Realm.Database.0.81.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.81.0\build\Realm.Database.targets')" />
   <Import Project="..\packages\Realm.0.81.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.81.0\build\Realm.targets')" />
-  <Import Project="..\packages\Realm.Database.0.83.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.0.83.0\build\Realm.Database.targets')" />
-  <Import Project="..\packages\Realm.0.83.0\build\Realm.targets" Condition="Exists('..\packages\Realm.0.83.0\build\Realm.targets')" />
+  <Import Project="..\packages\Realm.Database.1.0.3\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.1.0.3\build\Realm.Database.targets')" />
+  <Import Project="..\packages\Realm.1.0.3\build\Realm.targets" Condition="Exists('..\packages\Realm.1.0.3\build\Realm.targets')" />
 </Project>

--- a/Xamarin/iOS/LoginViewController.cs
+++ b/Xamarin/iOS/LoginViewController.cs
@@ -36,7 +36,6 @@ namespace DrawX.IOS
         private void DoLogin()
         {
             bool changedServer = DrawXSettingsManager.UpdateCredentials(ServerEntry.Text, UsernameEntry.Text, PasswordEntry.Text);
-            //// TODO handle failure to login
             OnCloseLogin(changedServer);
         }
 
@@ -53,11 +52,15 @@ namespace DrawX.IOS
                 DoLogin();
             };
 
+            // you can only cancel logging in if already logged in, otherwise it is meaningless
+            CancelButton.Enabled = (DrawXSettingsManager.LoggedInUser != null);
+                
             CancelButton.TouchUpInside += (sender, e) =>
             {
                 OnCloseLogin(false);
             };
 
+            #region Return key behaviour on keyboard - Next unti last field then Go
             ServerEntry.ShouldReturn += (textField) =>
             {
                 UsernameEntry.BecomeFirstResponder();
@@ -70,13 +73,13 @@ namespace DrawX.IOS
                 return false;
             };
 
-
             PasswordEntry.ShouldReturn += (textField) =>
             {
                 ((UITextField)textField).ResignFirstResponder();
                 DoLogin();
                 return false;
             };
+            #endregion
         }
 
     }

--- a/Xamarin/iOS/packages.config
+++ b/Xamarin/iOS/packages.config
@@ -2,21 +2,21 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="xamarinios10" />
   <package id="Fody" version="1.29.4" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Realm" version="0.81.0" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Realm.Database" version="0.81.0" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Realm" version="0.83.0" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Realm.Database" version="0.83.0" targetFramework="xamarinios10" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="xamarinios10" />
-  <package id="SkiaSharp" version="1.55.1" targetFramework="xamarinios10" />
-  <package id="SkiaSharp.Views" version="1.55.1" targetFramework="xamarinios10" />
+  <package id="SkiaSharp" version="1.56.0" targetFramework="xamarinios10" />
+  <package id="SkiaSharp.Views" version="1.56.0" targetFramework="xamarinios10" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="System.Collections" version="4.0.11" targetFramework="xamarinios10" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="xamarinios10" />
-  <package id="System.Linq" version="4.1.0" targetFramework="xamarinios10" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="xamarinios10" />
-  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="xamarinios10" />
-  <package id="System.ObjectModel" version="4.0.12" targetFramework="xamarinios10" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="xamarinios10" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="xamarinios10" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="xamarinios10" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="xamarinios10" />
-  <package id="System.Threading" version="4.0.11" targetFramework="xamarinios10" />
+  <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Linq" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Linq.Queryable" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
 </packages>

--- a/Xamarin/iOS/packages.config
+++ b/Xamarin/iOS/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="xamarinios10" />
   <package id="Fody" version="1.29.4" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Realm" version="0.83.0" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Realm.Database" version="0.83.0" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Realm" version="1.0.3" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Realm.Database" version="1.0.3" targetFramework="xamarinios10" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="xamarinios10" />
   <package id="SkiaSharp" version="1.56.0" targetFramework="xamarinios10" />
   <package id="SkiaSharp.Views" version="1.56.0" targetFramework="xamarinios10" />


### PR DESCRIPTION
Uses Realm 1.0.3 release candidate nugets.
Adds error handling and alert dialogs to the login process including auth failure due username/password or unreachable address.

Handles login again with different credentials.
Cancel button on login screen disabled on first login as it makes no sense to be able to Cancel at that point.