### PR TITLE
Add AD auth support

### DIFF
--- a/Xamarin/DrawXShared/ADCredentials.cs
+++ b/Xamarin/DrawXShared/ADCredentials.cs
@@ -1,0 +1,29 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+
+namespace DrawXShared
+{
+    public static class ADCredentials
+    {
+        public const string ClientId = "your-client-id";
+        public const string CommonAuthority = "https://login.windows.net/common";
+        public static Uri RedirectUri = new Uri("http://your-redirect-uri");
+    }
+}

--- a/Xamarin/DrawXShared/DrawXShared.projitems
+++ b/Xamarin/DrawXShared/DrawXShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DrawXSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawXSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedMedia.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ADCredentials.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Media\Charcoal.png" />

--- a/Xamarin/Droid/DrawX.Droid.csproj
+++ b/Xamarin/Droid/DrawX.Droid.csproj
@@ -62,6 +62,12 @@
     <Reference Include="Realm.Sync">
       <HintPath>..\packages\Realm.1.0.3\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.8\lib\MonoAndroid10\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.8\lib\MonoAndroid10\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/Xamarin/Droid/MainActivity.cs
+++ b/Xamarin/Droid/MainActivity.cs
@@ -22,6 +22,7 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using DrawXShared;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Realms.Sync;
 using SkiaSharp.Views.Android;
 
@@ -163,7 +164,7 @@ namespace DrawX.Droid
 
             _isEditingCredentials = true;
 
-            var dialog = new LoginDialog();
+            var dialog = new LoginDialog(this);
             dialog.PerformLoginAsync = async (credentials) =>
             {
                 var success = await SetupDrawer(() => User.LoginAsync(credentials, new Uri($"http://{DrawXSettingsManager.Settings.ServerIP}")));
@@ -179,6 +180,12 @@ namespace DrawX.Droid
             dialog.Cancelable = false;
 
             dialog.Show(FragmentManager, "login");
+        }
+
+        protected override void OnActivityResult(int requestCode, Result resultCode, Android.Content.Intent data)
+        {
+            base.OnActivityResult(requestCode, resultCode, data);
+            AuthenticationAgentContinuationHelper.SetAuthenticationAgentContinuationEventArgs(requestCode, resultCode, data);
         }
     }
 }

--- a/Xamarin/Droid/Resources/Resource.designer.cs
+++ b/Xamarin/Droid/Resources/Resource.designer.cs
@@ -26,6 +26,9 @@ namespace DrawX.Droid
 		
 		public static void UpdateIdValues()
 		{
+			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Id.agentWebView = global::DrawX.Droid.Resource.Id.agentWebView;
+			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Layout.WebAuthenticationBroker = global::DrawX.Droid.Resource.Layout.WebAuthenticationBroker;
+			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.String.ApplicationName = global::DrawX.Droid.Resource.String.ApplicationName;
 		}
 		
 		public partial class Attribute
@@ -43,6 +46,9 @@ namespace DrawX.Droid
 		
 		public partial class Id
 		{
+			
+			// aapt resource value: 0x7f050007
+			public const int agentWebView = 2131034119;
 			
 			// aapt resource value: 0x7f050006
 			public const int canvas = 2131034118;
@@ -84,6 +90,9 @@ namespace DrawX.Droid
 			// aapt resource value: 0x7f030001
 			public const int Main = 2130903041;
 			
+			// aapt resource value: 0x7f030002
+			public const int WebAuthenticationBroker = 2130903042;
+			
 			static Layout()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -113,11 +122,14 @@ namespace DrawX.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f040001
-			public const int app_name = 2130968577;
-			
 			// aapt resource value: 0x7f040000
-			public const int hello = 2130968576;
+			public const int ApplicationName = 2130968576;
+			
+			// aapt resource value: 0x7f040002
+			public const int app_name = 2130968578;
+			
+			// aapt resource value: 0x7f040001
+			public const int hello = 2130968577;
 			
 			static String()
 			{

--- a/Xamarin/Droid/Screens/LoginDialog.cs
+++ b/Xamarin/Droid/Screens/LoginDialog.cs
@@ -102,7 +102,17 @@ namespace DrawX.Droid
                 }
                 else if (v == _adLoginButton)
                 {
-                    // TODO: verify that server url has been input
+                    var clientId = ADCredentials.ClientId;
+                    if (clientId == "your-client-id")
+                    {
+                        throw new Exception("Please update ADCredentials.ClientId with the correct ClientId of your application.");
+                    }
+
+                    var redirectUri = ADCredentials.RedirectUri;
+                    if (redirectUri.AbsolutePath == "http://your-redirect-uri")
+                    {
+                        throw new Exception("Please update ADCredentials.RedirectUri with the correct RedirectUri of your application.");
+                    }
 
                     var authContext = new AuthenticationContext(ADCredentials.CommonAuthority);
                     var response = await authContext.AcquireTokenAsync("https://graph.windows.net", ADCredentials.ClientId, ADCredentials.RedirectUri, new PlatformParameters(_parentActivity));
@@ -116,7 +126,15 @@ namespace DrawX.Droid
             }
             catch (Exception ex)
             {
-                // TODO: handle
+                var tcs = new TaskCompletionSource<object>();
+                
+                new AlertDialog.Builder(Activity)
+                               .SetTitle("Unable to login")
+                               .SetMessage(ex.Message)
+                               .SetPositiveButton("OK", (_, __) => tcs.TrySetResult(null))
+                               .Show();
+
+                await tcs.Task;
             }
             finally
             {

--- a/Xamarin/Droid/packages.config
+++ b/Xamarin/Droid/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="monoandroid70" />
   <package id="Fody" version="1.29.4" targetFramework="monoandroid70" developmentDependency="true" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.8" targetFramework="monoandroid70" />
   <package id="Realm" version="1.0.3" targetFramework="monoandroid70" developmentDependency="true" />
   <package id="Realm.Database" version="1.0.3" targetFramework="monoandroid70" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="monoandroid70" />

--- a/Xamarin/iOS/DrawX.iOS.csproj
+++ b/Xamarin/iOS/DrawX.iOS.csproj
@@ -132,6 +132,12 @@
       <HintPath>..\packages\Realm.1.0.3\lib\Xamarin.iOS10\Realm.Sync.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.8\lib\Xamarin.iOS10\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.8\lib\Xamarin.iOS10\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />

--- a/Xamarin/iOS/LoginScreen.storyboard
+++ b/Xamarin/iOS/LoginScreen.storyboard
@@ -60,12 +60,24 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PxG-QJ-hvt">
+                                <rect key="frame" x="95" y="414" width="184" height="30"/>
+                                <state key="normal" title="Login with Active Directory"/>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ubW-XT-b9l">
+                                <rect key="frame" x="179" y="388" width="16" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="10" firstAttribute="leading" secondItem="19" secondAttribute="leading" id="1AB-aT-c5P"/>
+                            <constraint firstItem="PxG-QJ-hvt" firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="4ZM-JO-Xsg"/>
                             <constraint firstItem="10" firstAttribute="top" secondItem="19" secondAttribute="bottom" constant="30" id="8QX-Kq-aFe"/>
                             <constraint firstItem="20" firstAttribute="top" secondItem="10" secondAttribute="bottom" constant="10" id="9Zv-uK-LrL"/>
+                            <constraint firstItem="ubW-XT-b9l" firstAttribute="top" secondItem="52" secondAttribute="bottom" constant="5" id="Cbu-i9-qEW"/>
                             <constraint firstItem="19" firstAttribute="top" secondItem="9" secondAttribute="bottom" constant="10" id="F7V-wb-nUE"/>
                             <constraint firstItem="10" firstAttribute="trailing" secondItem="19" secondAttribute="trailing" id="ICD-fu-soe"/>
                             <constraint firstItem="20" firstAttribute="trailing" secondItem="19" secondAttribute="trailing" id="PS6-i7-B44"/>
@@ -79,13 +91,16 @@
                             <constraint firstItem="11" firstAttribute="top" secondItem="20" secondAttribute="bottom" constant="30" id="em6-VA-aXN"/>
                             <constraint firstItem="11" firstAttribute="leading" secondItem="19" secondAttribute="leading" id="fKv-ek-cny"/>
                             <constraint firstItem="21" firstAttribute="leading" secondItem="19" secondAttribute="leading" id="g49-aa-RW4"/>
+                            <constraint firstItem="PxG-QJ-hvt" firstAttribute="top" secondItem="ubW-XT-b9l" secondAttribute="bottom" constant="5" id="n0L-oB-S0m"/>
                             <constraint firstItem="52" firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="nTu-lt-IxD"/>
                             <constraint firstItem="19" firstAttribute="trailing" secondItem="9" secondAttribute="trailing" id="nci-5n-RC4"/>
                             <constraint firstItem="20" firstAttribute="leading" secondItem="19" secondAttribute="leading" id="pC9-Zu-rdf"/>
+                            <constraint firstItem="ubW-XT-b9l" firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="yjO-5M-CZs"/>
                             <constraint firstItem="19" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" id="ylZ-cR-gG2"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="ADLoginButton" destination="PxG-QJ-hvt" id="f2i-Gt-nKd"/>
                         <outlet property="LoginButton" destination="52" id="name-outlet-52"/>
                         <outlet property="PasswordEntry" destination="21" id="name-outlet-21"/>
                         <outlet property="PasswordLabel" destination="11" id="name-outlet-11"/>

--- a/Xamarin/iOS/LoginViewController.cs
+++ b/Xamarin/iOS/LoginViewController.cs
@@ -35,9 +35,39 @@ namespace DrawX.IOS
         {
         }
 
-        private async void LoginWithPassword()
+        private void LoginWithPassword()
         {
-            LoginButton.Enabled = false;
+            LoginCore(LoginButton, () => Task.FromResult(Credentials.UsernamePassword(UsernameEntry.Text, PasswordEntry.Text, false)));
+        }
+
+        private void LoginWithAD()
+        {
+            LoginCore(ADLoginButton, async () =>
+            {
+                var clientId = ADCredentials.ClientId;
+                if (clientId == "your-client-id")
+                {
+                    throw new Exception("Please update ADCredentials.ClientId with the correct ClientId of your application.");
+                }
+
+                var redirectUri = ADCredentials.RedirectUri;
+                if (redirectUri.AbsolutePath == "http://your-redirect-uri")
+                {
+                    throw new Exception("Please update ADCredentials.RedirectUri with the correct RedirectUri of your application.");
+                }
+
+                var authContext = new AuthenticationContext(ADCredentials.CommonAuthority);
+                var response = await authContext.AcquireTokenAsync("https://graph.windows.net", ADCredentials.ClientId, ADCredentials.RedirectUri, new PlatformParameters(this));
+
+                // TODO: uncomment when implemented
+                // var credentials = Credentials.ActiveDirectory(response.AccessToken);
+                return Credentials.Debug();
+            });
+        }
+
+        private async Task LoginCore(UIButton sender, Func<Task<Credentials>> getCredentialsFunc)
+        {
+            sender.Enabled = false;
             try
             {
                 DrawXSettingsManager.Write(() =>
@@ -46,42 +76,21 @@ namespace DrawX.IOS
                     DrawXSettingsManager.Settings.Username = UsernameEntry.Text;
                 });
 
-                var credentials = Credentials.UsernamePassword(UsernameEntry.Text, PasswordEntry.Text, false);
+                var credentials = await getCredentialsFunc();
 
                 await PerformLoginAsync(credentials);
             }
-            finally
-            {
-                LoginButton.Enabled = true;
-            }
-        }
-
-        private async void LoginWithAD()
-        {
-            // TODO: verify that server url has been input
-
-            ADLoginButton.Enabled = false;
-            try
-            {
-                DrawXSettingsManager.Write(() =>
-                {
-                    DrawXSettingsManager.Settings.ServerIP = ServerEntry.Text;
-                });
-
-                var authContext = new AuthenticationContext(ADCredentials.CommonAuthority);
-                var response = await authContext.AcquireTokenAsync("https://graph.windows.net", ADCredentials.ClientId, ADCredentials.RedirectUri, new PlatformParameters(this));
-
-                // TODO: uncomment when implemented
-                // var credentials = Credentials.ActiveDirectory(response.AccessToken);
-                var credentials = Credentials.Debug();
-            }
             catch (Exception ex)
             {
-                // TODO: handle
+                var tcs = new TaskCompletionSource<object>();
+                var alertController = UIAlertController.Create("Unable to login", ex.Message, UIAlertControllerStyle.Alert);
+                alertController.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, _ => tcs.TrySetResult(null)));
+                PresentViewController(alertController, animated: true, completionHandler: null);
+                await tcs.Task;
             }
             finally
             {
-                ADLoginButton.Enabled = true;
+                sender.Enabled = true;
             }
         }
 

--- a/Xamarin/iOS/LoginViewController.designer.cs
+++ b/Xamarin/iOS/LoginViewController.designer.cs
@@ -1,92 +1,82 @@
 // WARNING
 //
-// This file has been generated automatically by Xamarin Studio from the outlets and
-// actions declared in your storyboard file.
-// Manual changes to this file will not be maintained.
+// This file has been generated automatically by Xamarin Studio to store outlets and
+// actions made in the UI designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
 //
 using Foundation;
-using System;
 using System.CodeDom.Compiler;
-using UIKit;
 
 namespace DrawX.IOS
 {
-    [Register ("LoginViewController")]
-    partial class LoginViewController
-    {
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton CancelButton { get; set; }
+	[Register ("LoginViewController")]
+	partial class LoginViewController
+	{
+		[Outlet]
+		UIKit.UIButton ADLoginButton { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton LoginButton { get; set; }
+		[Outlet]
+		UIKit.UIButton LoginButton { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UITextField PasswordEntry { get; set; }
+		[Outlet]
+		UIKit.UITextField PasswordEntry { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UILabel PasswordLabel { get; set; }
+		[Outlet]
+		UIKit.UILabel PasswordLabel { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UITextField ServerEntry { get; set; }
+		[Outlet]
+		UIKit.UITextField ServerEntry { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UILabel ServerLabel { get; set; }
+		[Outlet]
+		UIKit.UILabel ServerLabel { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UITextField UsernameEntry { get; set; }
+		[Outlet]
+		UIKit.UITextField UsernameEntry { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UILabel UsernameLabel { get; set; }
+		[Outlet]
+		UIKit.UILabel UsernameLabel { get; set; }
+		
+		void ReleaseDesignerOutlets ()
+		{
+			if (LoginButton != null) {
+				LoginButton.Dispose ();
+				LoginButton = null;
+			}
 
-        void ReleaseDesignerOutlets ()
-        {
-            if (CancelButton != null) {
-                CancelButton.Dispose ();
-                CancelButton = null;
-            }
+			if (PasswordEntry != null) {
+				PasswordEntry.Dispose ();
+				PasswordEntry = null;
+			}
 
-            if (LoginButton != null) {
-                LoginButton.Dispose ();
-                LoginButton = null;
-            }
+			if (PasswordLabel != null) {
+				PasswordLabel.Dispose ();
+				PasswordLabel = null;
+			}
 
-            if (PasswordEntry != null) {
-                PasswordEntry.Dispose ();
-                PasswordEntry = null;
-            }
+			if (ServerEntry != null) {
+				ServerEntry.Dispose ();
+				ServerEntry = null;
+			}
 
-            if (PasswordLabel != null) {
-                PasswordLabel.Dispose ();
-                PasswordLabel = null;
-            }
+			if (ServerLabel != null) {
+				ServerLabel.Dispose ();
+				ServerLabel = null;
+			}
 
-            if (ServerEntry != null) {
-                ServerEntry.Dispose ();
-                ServerEntry = null;
-            }
+			if (UsernameEntry != null) {
+				UsernameEntry.Dispose ();
+				UsernameEntry = null;
+			}
 
-            if (ServerLabel != null) {
-                ServerLabel.Dispose ();
-                ServerLabel = null;
-            }
+			if (UsernameLabel != null) {
+				UsernameLabel.Dispose ();
+				UsernameLabel = null;
+			}
 
-            if (UsernameEntry != null) {
-                UsernameEntry.Dispose ();
-                UsernameEntry = null;
-            }
-
-            if (UsernameLabel != null) {
-                UsernameLabel.Dispose ();
-                UsernameLabel = null;
-            }
-        }
-    }
+			if (ADLoginButton != null) {
+				ADLoginButton.Dispose ();
+				ADLoginButton = null;
+			}
+		}
+	}
 }

--- a/Xamarin/iOS/packages.config
+++ b/Xamarin/iOS/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="xamarinios10" />
   <package id="Fody" version="1.29.4" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.8" targetFramework="xamarinios10" />
   <package id="Realm" version="1.0.3" targetFramework="xamarinios10" developmentDependency="true" />
   <package id="Realm.Database" version="1.0.3" targetFramework="xamarinios10" developmentDependency="true" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="xamarinios10" />


### PR DESCRIPTION
Adds logic to authenticate against azure AD.
Based on the refactored login flow #14 to allow getting the correct credentials and passing them along.

Uses `Credentials.Debug()` until we ship ROS supporting Active Directory.