### PR TITLE
Update Realm to 2.4.4

### DIFF
--- a/Apple/Podfile.lock
+++ b/Apple/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Realm (2.3.0):
-    - Realm/Headers (= 2.3.0)
-  - Realm/Headers (2.3.0)
+  - Realm (2.4.4):
+    - Realm/Headers (= 2.4.4)
+  - Realm/Headers (2.4.4)
   - RealmLoginKit (0.0.7):
     - Realm
     - TORoundedTableView
@@ -12,10 +12,10 @@ DEPENDENCIES:
   - RealmLoginKit
 
 SPEC CHECKSUMS:
-  Realm: 69d7de9aa569a11eed490aaabc8f2109e3985ecf
+  Realm: 5a280a1f5a9a3c267bebf4f41ee47911137703d7
   RealmLoginKit: e6b9cd0722b9ab51ee7930e496c6db3654f8e7aa
   TORoundedTableView: 4155565233135d81d6626a0c4ecfba27991cf2b1
 
 PODFILE CHECKSUM: b38f68297708669f31f58c893995f54babdad3fc
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0


### PR DESCRIPTION
Update Realm to 2.4.4

I confirmed it can open and sync by updating previous version of app. @TimOliver 